### PR TITLE
Sets mailer domain to heroku for testing

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -89,7 +89,7 @@ Rails.application.configure do
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
 
-  config.action_mailer.default_url_options = { host: 'pange.as' }
+  config.action_mailer.default_url_options = { host: 'pangeas.herokuapp.com' }
 
   # Setup the mailer config
   config.action_mailer.delivery_method = :smtp
@@ -97,7 +97,7 @@ Rails.application.configure do
   config.action_mailer.smtp_settings = {
    :user_name => ENV['SENDGRID_USERNAME'],
    :password => ENV['SENDGRID_PASSWORD'],
-   :domain => 'pange.as',
+   :domain => 'pangeas.herokuapp.com',
    :address => 'smtp.sendgrid.net',
    :port => 587,
    :authentication => :plain,


### PR DESCRIPTION
The password recovery email was sending a link to 'pange.as/...', generating a 404 on their current website.