### PR TITLE
Adds CPF and address to user

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -37,7 +37,7 @@ class ApplicationController < ActionController::Base
 
   def configure_permitted_parameters
     devise_parameter_sanitizer.permit(
-      :sign_up, keys: permitted_user_sign_up_parameters
+      :sign_up, keys: permitted_sign_up_parameters
     )
     devise_parameter_sanitizer.permit(
       :account_update,
@@ -51,7 +51,7 @@ class ApplicationController < ActionController::Base
     sections_path
   end
 
-  def permitted_user_sign_up_parameters
+  def permitted_sign_up_parameters
     %i[
       first_name last_name affiliate_tag cpf address address_number
       address_complement zip_code neighborhood city state country

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -54,8 +54,7 @@ class ApplicationController < ActionController::Base
   def permitted_user_sign_up_parameters
     %i[
       first_name last_name affiliate_tag cpf address address_number
-      address_complement zip_code neighborhood city state country phone
-      mobile_phone
+      address_complement zip_code neighborhood city state country
     ]
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -37,7 +37,7 @@ class ApplicationController < ActionController::Base
 
   def configure_permitted_parameters
     devise_parameter_sanitizer.permit(
-      :sign_up, keys: %i[first_name last_name affiliate_tag]
+      :sign_up, keys: permitted_user_sign_up_parameters
     )
     devise_parameter_sanitizer.permit(
       :account_update,
@@ -49,5 +49,13 @@ class ApplicationController < ActionController::Base
 
   def after_sign_in_path_for(_resource)
     sections_path
+  end
+
+  def permitted_user_sign_up_parameters
+    %i[
+      first_name last_name affiliate_tag cpf address address_number
+      address_complement zip_code neighborhood city state country phone
+      mobile_phone
+    ]
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,7 +12,14 @@ class User < ApplicationRecord
 
   validates :first_name, presence: true
   validates :last_name, presence: true
-
+  validates :cpf, presence: true
+  validates :zip_code, presence: true
+  validates :address, presence: true
+  validates :address_number, presence: true
+  validates :city, presence: true
+  validates :state, presence: true
+  validates :country, presence: true
+  validates :phone, presence: true
   has_many :subscriptions, dependent: :restrict_with_exception
 
   def subscribed?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -19,7 +19,6 @@ class User < ApplicationRecord
   validates :city, presence: true
   validates :state, presence: true
   validates :country, presence: true
-  validates :phone, presence: true
   has_many :subscriptions, dependent: :restrict_with_exception
 
   def subscribed?

--- a/app/views/devise/registrations/new.html.slim
+++ b/app/views/devise/registrations/new.html.slim
@@ -71,14 +71,6 @@
                   = f.text_field :country,
                     class: 'large-12 cell pink-input',
                     placeholder: 'País'
-                .medium-6.cell
-                  = f.text_field :phone,
-                    class: 'large-12 cell pink-input',
-                    placeholder: 'Telefone'
-                .medium-6.cell
-                  = f.text_field :mobile_phone,
-                    class: 'large-12 cell pink-input',
-                    placeholder: 'Celular (opcional)'
               .grid-x
                 .large-12.cell
                   = f.submit  t('.sign_up', default: 'Sign up'),

--- a/app/views/devise/registrations/new.html.slim
+++ b/app/views/devise/registrations/new.html.slim
@@ -1,7 +1,7 @@
 .forms-container
   .grid-container
     .devise-form.grid-x
-      .medium-8.medium-centered.cell
+      .medium-11.medium-centered.large-8.cell
         .grid-x.grid-padding-x
           .large-12.cell
             = foundation_devise_error_messages!
@@ -12,32 +12,73 @@
               input type='hidden' name='recurrence' value=params[:recurrence]
               = f.hidden_field :affiliate_tag,
                 value: request.env['affiliate.tag']
-              .grid-x
-                .large-12.cell
+              .grid-x.grid-padding-x.mb-2rem
+                .medium-6.cell
                   = f.text_field :first_name, autofocus: true,
                     class: 'pink-input',
                     placeholder: 'DIGITE SEU NOME AQUI'
-              .grid-x
-                .large-12.cell
+                .medium-6.cell
                   = f.text_field :last_name,
                     class: 'large-12 cell pink-input',
                     placeholder: 'DIGITE SEU SOBRENOME AQUI'
-              .grid-x
-                .large-12.cell
+                .medium-6.cell
                   = f.email_field :email,
                     class: 'large-12 cell pink-input',
                     placeholder: 'DIGITE SEU E-MAIL AQUI'
-              .grid-x
-                .large-12.cell
+                .medium-6.cell
+                  = f.text_field :cpf,
+                    class: 'large-12 cell pink-input',
+                    placeholder: 'DIGITE SEU CPF AQUI'
+                .medium-6.cell
                   = f.password_field :password, autocomplete: 'off',
                     class: 'large-12 cell pink-input',
                     placeholder: 'DIGITE SUA SENHA AQUI'
-              .grid-x
-                .large-12.cell
+                .medium-6.cell
                   = f.password_field :password_confirmation,
                     autocomplete: 'off',
                     class: 'large-12 cell pink-input',
                     placeholder: 'CONFIRME SUA SENHA'
+              .grid-x.grid-padding-x
+                .medium-6.cell
+                  = f.text_field :address,
+                    class: 'large-12 cell pink-input',
+                    placeholder: 'Endereço'
+                .medium-6.cell
+                  = f.text_field :address_number,
+                    class: 'large-12 cell pink-input',
+                    placeholder: 'Número'
+                .medium-6.cell
+                  = f.text_field :address_complement,
+                    class: 'large-12 cell pink-input',
+                    placeholder: 'Complemento (opcional)'
+                .medium-6.cell
+                  = f.text_field :zip_code,
+                    class: 'large-12 cell pink-input',
+                    placeholder: 'CEP'
+                .medium-6.cell
+                  = f.text_field :neighborhood,
+                    class: 'large-12 cell pink-input',
+                    placeholder: 'Bairro'
+                .medium-6.cell
+                  = f.text_field :city,
+                    class: 'large-12 cell pink-input',
+                    placeholder: 'Cidade'
+                .medium-6.cell
+                  = f.text_field :state,
+                    class: 'large-12 cell pink-input',
+                    placeholder: 'Estado'
+                .medium-6.cell
+                  = f.text_field :country,
+                    class: 'large-12 cell pink-input',
+                    placeholder: 'País'
+                .medium-6.cell
+                  = f.text_field :phone,
+                    class: 'large-12 cell pink-input',
+                    placeholder: 'Telefone'
+                .medium-6.cell
+                  = f.text_field :mobile_phone,
+                    class: 'large-12 cell pink-input',
+                    placeholder: 'Celular (opcional)'
               .grid-x
                 .large-12.cell
                   = f.submit  t('.sign_up', default: 'Sign up'),

--- a/db/migrate/20171122192715_add_address_to_users.rb
+++ b/db/migrate/20171122192715_add_address_to_users.rb
@@ -1,13 +1,13 @@
 class AddAddressToUsers < ActiveRecord::Migration[5.1]
   def change
-    add_column :users, :cpf, :string
-    add_column :users, :address, :string
-    add_column :users, :address_number, :string
+    add_column :users, :cpf, :string, null: false
+    add_column :users, :address, :string, null: false
+    add_column :users, :address_number, :string, null: false
     add_column :users, :address_complement, :string
     add_column :users, :neighborhood, :string
-    add_column :users, :city, :string
-    add_column :users, :state, :string
-    add_column :users, :country, :string
-    add_column :users, :zip_code, :string
+    add_column :users, :city, :string, null: false
+    add_column :users, :state, :string, null: false
+    add_column :users, :country, :string, null: false
+    add_column :users, :zip_code, :string, null: false
   end
 end

--- a/db/migrate/20171122192715_add_address_to_users.rb
+++ b/db/migrate/20171122192715_add_address_to_users.rb
@@ -1,0 +1,15 @@
+class AddAddressToUsers < ActiveRecord::Migration[5.1]
+  def change
+    add_column :users, :cpf, :string
+    add_column :users, :address, :string
+    add_column :users, :address_number, :string
+    add_column :users, :address_complement, :string
+    add_column :users, :neighborhood, :string
+    add_column :users, :city, :string
+    add_column :users, :state, :string
+    add_column :users, :country, :string
+    add_column :users, :phone, :string
+    add_column :users, :mobile_phone, :string
+    add_column :users, :zip_code, :string
+  end
+end

--- a/db/migrate/20171122192715_add_address_to_users.rb
+++ b/db/migrate/20171122192715_add_address_to_users.rb
@@ -8,8 +8,6 @@ class AddAddressToUsers < ActiveRecord::Migration[5.1]
     add_column :users, :city, :string
     add_column :users, :state, :string
     add_column :users, :country, :string
-    add_column :users, :phone, :string
-    add_column :users, :mobile_phone, :string
     add_column :users, :zip_code, :string
   end
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -2,14 +2,30 @@ user = User.create!(
   first_name: 'foo',
   last_name: 'bar',
   email: 'foo@bar.com',
-  password: '123456'
+  password: '123456',
+  cpf: '1234567890',
+  address: 'foo',
+  address_number: '42',
+  zip_code: '123',
+  city: 'foo',
+  state: 'foo',
+  country: 'foo',
+  phone: '123456'
 )
 
 User.create!(
   first_name: 'john',
   last_name: 'doe',
   email: 'john@doe.com',
-  password: '123456'
+  password: '123456',
+  cpf: '1234567890',
+  address: 'foo',
+  address_number: '42',
+  zip_code: '123',
+  city: 'foo',
+  state: 'foo',
+  country: 'foo',
+  phone: '123456'
 )
 
 Subscription.create!(

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -9,8 +9,7 @@ user = User.create!(
   zip_code: '123',
   city: 'foo',
   state: 'foo',
-  country: 'foo',
-  phone: '123456'
+  country: 'foo'
 )
 
 User.create!(
@@ -24,8 +23,7 @@ User.create!(
   zip_code: '123',
   city: 'foo',
   state: 'foo',
-  country: 'foo',
-  phone: '123456'
+  country: 'foo'  
 )
 
 Subscription.create!(

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -264,7 +264,18 @@ CREATE TABLE users (
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
     iugu_id character varying,
-    affiliate_tag character varying
+    affiliate_tag character varying,
+    cpf character varying,
+    address character varying,
+    address_number character varying,
+    address_complement character varying,
+    neighborhood character varying,
+    city character varying,
+    state character varying,
+    country character varying,
+    phone character varying,
+    mobile_phone character varying,
+    zip_code character varying
 );
 
 
@@ -580,6 +591,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20171030201522'),
 ('20171106133117'),
 ('20171106133210'),
-('20171120121856');
+('20171120121856'),
+('20171122192715');
 
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -273,8 +273,6 @@ CREATE TABLE users (
     city character varying,
     state character varying,
     country character varying,
-    phone character varying,
-    mobile_phone character varying,
     zip_code character varying
 );
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -265,15 +265,15 @@ CREATE TABLE users (
     updated_at timestamp without time zone NOT NULL,
     iugu_id character varying,
     affiliate_tag character varying,
-    cpf character varying,
-    address character varying,
-    address_number character varying,
+    cpf character varying NOT NULL,
+    address character varying NOT NULL,
+    address_number character varying NOT NULL,
     address_complement character varying,
     neighborhood character varying,
-    city character varying,
-    state character varying,
-    country character varying,
-    zip_code character varying
+    city character varying NOT NULL,
+    state character varying NOT NULL,
+    country character varying NOT NULL,
+    zip_code character varying NOT NULL
 );
 
 

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -22,8 +22,7 @@ RSpec.describe Subscription, recurrence: :model do
       zip_code: '123',
       city: 'foo',
       state: 'foo',
-      country: 'foo',
-      phone: '123456'
+      country: 'foo'
     )
   end
 

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -15,7 +15,15 @@ RSpec.describe Subscription, recurrence: :model do
       email: 'foo@bar.com',
       first_name: 'Foo',
       last_name: 'Bar',
-      password: 'foobarfoo'
+      password: 'foobarfoo',
+      cpf: '1234567890',
+      address: 'foo',
+      address_number: '42',
+      zip_code: '123',
+      city: 'foo',
+      state: 'foo',
+      country: 'foo',
+      phone: '123456'
     )
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -15,8 +15,7 @@ RSpec.describe User, type: :model do
       zip_code: '123',
       city: 'foo',
       state: 'foo',
-      country: 'foo',
-      phone: '123456'
+      country: 'foo'
     )
   end
 
@@ -34,7 +33,6 @@ RSpec.describe User, type: :model do
     it { is_expected.to validate_presence_of(:city) }
     it { is_expected.to validate_presence_of(:state) }
     it { is_expected.to validate_presence_of(:country) }
-    it { is_expected.to validate_presence_of(:phone) }
   end
 
   describe 'subscribed?' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -8,7 +8,15 @@ RSpec.describe User, type: :model do
       first_name: 'john',
       last_name: 'doe',
       email: 'foo@bar.com',
-      password: '123456'
+      password: '123456',
+      cpf: '1234567890',
+      address: 'foo',
+      address_number: '42',
+      zip_code: '123',
+      city: 'foo',
+      state: 'foo',
+      country: 'foo',
+      phone: '123456'
     )
   end
 
@@ -19,6 +27,14 @@ RSpec.describe User, type: :model do
   describe 'validations' do
     it { is_expected.to validate_presence_of(:first_name) }
     it { is_expected.to validate_presence_of(:last_name) }
+    it { is_expected.to validate_presence_of(:cpf) }
+    it { is_expected.to validate_presence_of(:zip_code) }
+    it { is_expected.to validate_presence_of(:address) }
+    it { is_expected.to validate_presence_of(:address_number) }
+    it { is_expected.to validate_presence_of(:city) }
+    it { is_expected.to validate_presence_of(:state) }
+    it { is_expected.to validate_presence_of(:country) }
+    it { is_expected.to validate_presence_of(:phone) }
   end
 
   describe 'subscribed?' do

--- a/spec/policies/application_policy_spec.rb
+++ b/spec/policies/application_policy_spec.rb
@@ -18,8 +18,7 @@ RSpec.describe ApplicationPolicy do
       zip_code: '123',
       city: 'foo',
       state: 'foo',
-      country: 'foo',
-      phone: '123456'
+      country: 'foo'
     )
   end
 

--- a/spec/policies/application_policy_spec.rb
+++ b/spec/policies/application_policy_spec.rb
@@ -11,7 +11,15 @@ RSpec.describe ApplicationPolicy do
       last_name: 'doe',
       email: 'foo@bar.com',
       password: '123456',
-      admin: admin
+      cpf: '1234567890',
+      admin: admin,
+      address: 'foo',
+      address_number: '42',
+      zip_code: '123',
+      city: 'foo',
+      state: 'foo',
+      country: 'foo',
+      phone: '123456'
     )
   end
 

--- a/spec/policies/user_policy_spec.rb
+++ b/spec/policies/user_policy_spec.rb
@@ -18,8 +18,7 @@ RSpec.describe UserPolicy do
       zip_code: '123',
       city: 'foo',
       state: 'foo',
-      country: 'foo',
-      phone: '123456'
+      country: 'foo'
     )
   end
 
@@ -56,8 +55,7 @@ RSpec.describe UserPolicy do
             zip_code: '123',
             city: 'foo',
             state: 'foo',
-            country: 'foo',
-            phone: '123456'
+            country: 'foo'
           )
         end
 
@@ -80,8 +78,7 @@ RSpec.describe UserPolicy do
           zip_code: '123',
           city: 'foo',
           state: 'foo',
-          country: 'foo',
-          phone: '123456'
+          country: 'foo'
         )
       end
 

--- a/spec/policies/user_policy_spec.rb
+++ b/spec/policies/user_policy_spec.rb
@@ -11,7 +11,15 @@ RSpec.describe UserPolicy do
       last_name: 'doe',
       email: 'foo@bar.com',
       password: '123456',
-      admin: admin
+      cpf: '1234567890',
+      admin: admin,
+      address: 'foo',
+      address_number: '42',
+      zip_code: '123',
+      city: 'foo',
+      state: 'foo',
+      country: 'foo',
+      phone: '123456'
     )
   end
 
@@ -41,7 +49,15 @@ RSpec.describe UserPolicy do
             first_name: 'john',
             last_name: 'doe',
             email: 'foo@baz.com',
-            password: '123456'
+            password: '123456',
+            cpf: '1234567890',
+            address: 'foo',
+            address_number: '42',
+            zip_code: '123',
+            city: 'foo',
+            state: 'foo',
+            country: 'foo',
+            phone: '123456'
           )
         end
 
@@ -57,7 +73,15 @@ RSpec.describe UserPolicy do
           first_name: 'john',
           last_name: 'doe',
           email: 'foo@baz.com',
-          password: '123456'
+          password: '123456',
+          cpf: '1234567890',
+          address: 'foo',
+          address_number: '42',
+          zip_code: '123',
+          city: 'foo',
+          state: 'foo',
+          country: 'foo',
+          phone: '123456'
         )
       end
 

--- a/spec/requests/categories/show_spec.rb
+++ b/spec/requests/categories/show_spec.rb
@@ -42,7 +42,15 @@ RSpec.describe 'GET /categories/:id', type: :request do
         first_name: 'jane',
         last_name: 'doe',
         email: 'bar@baz.com',
-        password: '123456'
+        password: '123456',
+        cpf: '1234567890',
+        address: 'foo',
+        address_number: '42',
+        zip_code: '123',
+        city: 'foo',
+        state: 'foo',
+        country: 'foo',
+        phone: '123456'
       )
     end
 

--- a/spec/requests/categories/show_spec.rb
+++ b/spec/requests/categories/show_spec.rb
@@ -49,8 +49,7 @@ RSpec.describe 'GET /categories/:id', type: :request do
         zip_code: '123',
         city: 'foo',
         state: 'foo',
-        country: 'foo',
-        phone: '123456'
+        country: 'foo'
       )
     end
 

--- a/spec/requests/payments/new_spec.rb
+++ b/spec/requests/payments/new_spec.rb
@@ -21,7 +21,15 @@ RSpec.describe 'GET /payments/new', type: :request do
         first_name: 'jane',
         last_name: 'doe',
         email: 'bar@baz.com',
-        password: '123456'
+        password: '123456',
+        cpf: '1234567890',
+        address: 'foo',
+        address_number: '42',
+        zip_code: '123',
+        city: 'foo',
+        state: 'foo',
+        country: 'foo',
+        phone: '123456'
       )
     end
 

--- a/spec/requests/payments/new_spec.rb
+++ b/spec/requests/payments/new_spec.rb
@@ -28,8 +28,7 @@ RSpec.describe 'GET /payments/new', type: :request do
         zip_code: '123',
         city: 'foo',
         state: 'foo',
-        country: 'foo',
-        phone: '123456'
+        country: 'foo'
       )
     end
 

--- a/spec/requests/sections/index_spec.rb
+++ b/spec/requests/sections/index_spec.rb
@@ -27,7 +27,15 @@ RSpec.describe 'GET /sections', type: :request do
         first_name: 'jane',
         last_name: 'doe',
         email: 'bar@baz.com',
-        password: '123456'
+        password: '123456',
+        cpf: '1234567890',
+        address: 'foo',
+        address_number: '42',
+        zip_code: '123',
+        city: 'foo',
+        state: 'foo',
+        country: 'foo',
+        phone: '123456'
       )
     end
 

--- a/spec/requests/sections/index_spec.rb
+++ b/spec/requests/sections/index_spec.rb
@@ -34,8 +34,7 @@ RSpec.describe 'GET /sections', type: :request do
         zip_code: '123',
         city: 'foo',
         state: 'foo',
-        country: 'foo',
-        phone: '123456'
+        country: 'foo'
       )
     end
 

--- a/spec/requests/sections/show_courses_spec.rb
+++ b/spec/requests/sections/show_courses_spec.rb
@@ -34,8 +34,7 @@ RSpec.describe 'GET /sections/3', type: :request do
         zip_code: '123',
         city: 'foo',
         state: 'foo',
-        country: 'foo',
-        phone: '123456'
+        country: 'foo'
       )
     end
 

--- a/spec/requests/sections/show_courses_spec.rb
+++ b/spec/requests/sections/show_courses_spec.rb
@@ -27,7 +27,15 @@ RSpec.describe 'GET /sections/3', type: :request do
         first_name: 'john',
         last_name: 'doe',
         email: 'foo@bar.com',
-        password: '123456'
+        password: '123456',
+        cpf: '1234567890',
+        address: 'foo',
+        address_number: '42',
+        zip_code: '123',
+        city: 'foo',
+        state: 'foo',
+        country: 'foo',
+        phone: '123456'
       )
     end
 

--- a/spec/requests/sections/show_events_spec.rb
+++ b/spec/requests/sections/show_events_spec.rb
@@ -47,8 +47,7 @@ RSpec.describe 'GET /sections/1', type: :request do
         zip_code: '123',
         city: 'foo',
         state: 'foo',
-        country: 'foo',
-        phone: '123456'
+        country: 'foo'
       )
     end
 

--- a/spec/requests/sections/show_events_spec.rb
+++ b/spec/requests/sections/show_events_spec.rb
@@ -40,7 +40,15 @@ RSpec.describe 'GET /sections/1', type: :request do
         first_name: 'john',
         last_name: 'doe',
         email: 'foo@bar.com',
-        password: '123456'
+        password: '123456',
+        cpf: '1234567890',
+        address: 'foo',
+        address_number: '42',
+        zip_code: '123',
+        city: 'foo',
+        state: 'foo',
+        country: 'foo',
+        phone: '123456'
       )
     end
 

--- a/spec/requests/sections/show_spec.rb
+++ b/spec/requests/sections/show_spec.rb
@@ -27,7 +27,15 @@ RSpec.describe 'GET /sections/:id', type: :request do
         first_name: 'john',
         last_name: 'doe',
         email: 'foo@bar.com',
-        password: '123456'
+        password: '123456',
+        cpf: '1234567890',
+        address: 'foo',
+        address_number: '42',
+        zip_code: '123',
+        city: 'foo',
+        state: 'foo',
+        country: 'foo',
+        phone: '123456'
       )
     end
 

--- a/spec/requests/sections/show_spec.rb
+++ b/spec/requests/sections/show_spec.rb
@@ -34,8 +34,7 @@ RSpec.describe 'GET /sections/:id', type: :request do
         zip_code: '123',
         city: 'foo',
         state: 'foo',
-        country: 'foo',
-        phone: '123456'
+        country: 'foo'
       )
     end
 

--- a/spec/requests/series/show_spec.rb
+++ b/spec/requests/series/show_spec.rb
@@ -53,7 +53,15 @@ RSpec.describe 'GET /series/:id', type: :request do
         first_name: 'john',
         last_name: 'doe',
         email: 'foo@bar.com',
-        password: '123456'
+        password: '123456',
+        cpf: '1234567890',
+        address: 'foo',
+        address_number: '42',
+        zip_code: '123',
+        city: 'foo',
+        state: 'foo',
+        country: 'foo',
+        phone: '123456'
       )
     end
 

--- a/spec/requests/series/show_spec.rb
+++ b/spec/requests/series/show_spec.rb
@@ -60,8 +60,7 @@ RSpec.describe 'GET /series/:id', type: :request do
         zip_code: '123',
         city: 'foo',
         state: 'foo',
-        country: 'foo',
-        phone: '123456'
+        country: 'foo'
       )
     end
 

--- a/spec/requests/subscriptions/activate_spec.rb
+++ b/spec/requests/subscriptions/activate_spec.rb
@@ -18,8 +18,7 @@ RSpec.describe 'POST /subscriptions/activate', type: :request do
       zip_code: '123',
       city: 'foo',
       state: 'foo',
-      country: 'foo',
-      phone: '123456'
+      country: 'foo'
     )
   end
 

--- a/spec/requests/subscriptions/activate_spec.rb
+++ b/spec/requests/subscriptions/activate_spec.rb
@@ -11,7 +11,15 @@ RSpec.describe 'POST /subscriptions/activate', type: :request do
       last_name: 'doe',
       email: 'bar@baz.com',
       password: '123456',
-      iugu_id: '1'
+      cpf: '1234567890',
+      iugu_id: '1',
+      address: 'foo',
+      address_number: '42',
+      zip_code: '123',
+      city: 'foo',
+      state: 'foo',
+      country: 'foo',
+      phone: '123456'
     )
   end
 

--- a/spec/requests/subscriptions/create_spec.rb
+++ b/spec/requests/subscriptions/create_spec.rb
@@ -18,8 +18,7 @@ RSpec.describe 'POST /subscriptions/create', type: :request do
       zip_code: '123',
       city: 'foo',
       state: 'foo',
-      country: 'foo',
-      phone: '123456'
+      country: 'foo'
     )
   end
 

--- a/spec/requests/subscriptions/create_spec.rb
+++ b/spec/requests/subscriptions/create_spec.rb
@@ -11,7 +11,15 @@ RSpec.describe 'POST /subscriptions/create', type: :request do
       last_name: 'doe',
       email: 'bar@baz.com',
       password: '123456',
-      iugu_id: '1'
+      cpf: '1234567890',
+      iugu_id: '1',
+      address: 'foo',
+      address_number: '42',
+      zip_code: '123',
+      city: 'foo',
+      state: 'foo',
+      country: 'foo',
+      phone: '123456'
     )
   end
 

--- a/spec/requests/subscriptions/new_spec.rb
+++ b/spec/requests/subscriptions/new_spec.rb
@@ -19,7 +19,15 @@ RSpec.describe 'GET /subscriptions/new', type: :request do
         first_name: 'jane',
         last_name: 'doe',
         email: 'bar@baz.com',
-        password: '123456'
+        password: '123456',
+        cpf: '1234567890',
+        address: 'foo',
+        address_number: '42',
+        zip_code: '123',
+        city: 'foo',
+        state: 'foo',
+        country: 'foo',
+        phone: '123456'
       )
     end
 

--- a/spec/requests/subscriptions/new_spec.rb
+++ b/spec/requests/subscriptions/new_spec.rb
@@ -26,8 +26,7 @@ RSpec.describe 'GET /subscriptions/new', type: :request do
         zip_code: '123',
         city: 'foo',
         state: 'foo',
-        country: 'foo',
-        phone: '123456'
+        country: 'foo'
       )
     end
 

--- a/spec/requests/subscriptions/show_spec.rb
+++ b/spec/requests/subscriptions/show_spec.rb
@@ -17,8 +17,7 @@ RSpec.describe 'GET /subscriptions/:id', type: :request do
       zip_code: '123',
       city: 'foo',
       state: 'foo',
-      country: 'foo',
-      phone: '123456'
+      country: 'foo'
     )
   end
 
@@ -61,8 +60,7 @@ RSpec.describe 'GET /subscriptions/:id', type: :request do
           zip_code: '123',
           city: 'foo',
           state: 'foo',
-          country: 'foo',
-          phone: '123456'
+          country: 'foo'
         )
       end
 
@@ -88,8 +86,7 @@ RSpec.describe 'GET /subscriptions/:id', type: :request do
           zip_code: '123',
           city: 'foo',
           state: 'foo',
-          country: 'foo',
-          phone: '123456'
+          country: 'foo'
         )
       end
 

--- a/spec/requests/subscriptions/show_spec.rb
+++ b/spec/requests/subscriptions/show_spec.rb
@@ -10,7 +10,15 @@ RSpec.describe 'GET /subscriptions/:id', type: :request do
       first_name: 'jane',
       last_name: 'doe',
       email: 'bar@baz.com',
-      password: '123456'
+      password: '123456',
+      cpf: '1234567890',
+      address: 'foo',
+      address_number: '42',
+      zip_code: '123',
+      city: 'foo',
+      state: 'foo',
+      country: 'foo',
+      phone: '123456'
     )
   end
 
@@ -46,7 +54,15 @@ RSpec.describe 'GET /subscriptions/:id', type: :request do
           first_name: 'john',
           last_name: 'doe',
           email: 'foo@baz.com',
-          password: '123456'
+          password: '123456',
+          cpf: '1234567890',
+          address: 'foo',
+          address_number: '42',
+          zip_code: '123',
+          city: 'foo',
+          state: 'foo',
+          country: 'foo',
+          phone: '123456'
         )
       end
 
@@ -65,7 +81,15 @@ RSpec.describe 'GET /subscriptions/:id', type: :request do
           last_name: 'doe',
           email: 'foo@baz.com',
           password: '123456',
-          admin: true
+          cpf: '1234567890',
+          admin: true,
+          address: 'foo',
+          address_number: '42',
+          zip_code: '123',
+          city: 'foo',
+          state: 'foo',
+          country: 'foo',
+          phone: '123456'
         )
       end
 

--- a/spec/requests/users/show_spec.rb
+++ b/spec/requests/users/show_spec.rb
@@ -10,7 +10,15 @@ RSpec.describe 'GET /users/:id', type: :request do
       first_name: 'jane',
       last_name: 'doe',
       email: 'bar@baz.com',
-      password: '123456'
+      password: '123456',
+      cpf: '1234567890',
+      address: 'foo',
+      address_number: '42',
+      zip_code: '123',
+      city: 'foo',
+      state: 'foo',
+      country: 'foo',
+      phone: '123456'
     )
   end
 
@@ -38,7 +46,15 @@ RSpec.describe 'GET /users/:id', type: :request do
           first_name: 'john',
           last_name: 'doe',
           email: 'foo@baz.com',
-          password: '123456'
+          password: '123456',
+          cpf: '1234567890',
+          address: 'foo',
+          address_number: '42',
+          zip_code: '123',
+          city: 'foo',
+          state: 'foo',
+          country: 'foo',
+          phone: '123456'
         )
       end
 
@@ -57,7 +73,15 @@ RSpec.describe 'GET /users/:id', type: :request do
           last_name: 'doe',
           email: 'foo@baz.com',
           password: '123456',
-          admin: true
+          cpf: '1234567890',
+          admin: true,
+          address: 'foo',
+          address_number: '42',
+          zip_code: '123',
+          city: 'foo',
+          state: 'foo',
+          country: 'foo',
+          phone: '123456'
         )
       end
 

--- a/spec/requests/users/show_spec.rb
+++ b/spec/requests/users/show_spec.rb
@@ -17,8 +17,7 @@ RSpec.describe 'GET /users/:id', type: :request do
       zip_code: '123',
       city: 'foo',
       state: 'foo',
-      country: 'foo',
-      phone: '123456'
+      country: 'foo'
     )
   end
 
@@ -53,8 +52,7 @@ RSpec.describe 'GET /users/:id', type: :request do
           zip_code: '123',
           city: 'foo',
           state: 'foo',
-          country: 'foo',
-          phone: '123456'
+          country: 'foo'
         )
       end
 
@@ -80,8 +78,7 @@ RSpec.describe 'GET /users/:id', type: :request do
           zip_code: '123',
           city: 'foo',
           state: 'foo',
-          country: 'foo',
-          phone: '123456'
+          country: 'foo'
         )
       end
 

--- a/spec/requests/users/sign_in_spec.rb
+++ b/spec/requests/users/sign_in_spec.rb
@@ -10,7 +10,15 @@ RSpec.describe 'GET /users/sign_in', type: :request do
       first_name: 'john',
       last_name: 'doe',
       email: 'foo@bar.com',
-      password: '123456'
+      password: '123456',
+      cpf: '1234567890',
+      address: 'foo',
+      address_number: '42',
+      zip_code: '123',
+      city: 'foo',
+      state: 'foo',
+      country: 'foo',
+      phone: '123456'
     )
   end
 

--- a/spec/requests/users/sign_in_spec.rb
+++ b/spec/requests/users/sign_in_spec.rb
@@ -17,8 +17,7 @@ RSpec.describe 'GET /users/sign_in', type: :request do
       zip_code: '123',
       city: 'foo',
       state: 'foo',
-      country: 'foo',
-      phone: '123456'
+      country: 'foo'
     )
   end
 

--- a/spec/requests/users/sign_up_spec.rb
+++ b/spec/requests/users/sign_up_spec.rb
@@ -18,8 +18,7 @@ RSpec.describe 'GET /users/sign_up', type: :request do
         zip_code: '123',
         city: 'foo',
         state: 'foo',
-        country: 'foo',
-        phone: '123456'
+        country: 'foo'
       }
     end
 

--- a/spec/requests/users/sign_up_spec.rb
+++ b/spec/requests/users/sign_up_spec.rb
@@ -11,7 +11,15 @@ RSpec.describe 'GET /users/sign_up', type: :request do
         first_name: 'foo',
         last_name: 'bar',
         email: 'foo@bar.com',
-        password: '123456'
+        password: '123456',
+        cpf: '1234567890',
+        address: 'foo',
+        address_number: '42',
+        zip_code: '123',
+        city: 'foo',
+        state: 'foo',
+        country: 'foo',
+        phone: '123456'
       }
     end
 

--- a/spec/requests/videos/show_spec.rb
+++ b/spec/requests/videos/show_spec.rb
@@ -31,7 +31,15 @@ RSpec.describe 'GET /videos/:id', type: :request do
         first_name: 'john',
         last_name: 'doe',
         email: 'foo@bar.com',
-        password: '123456'
+        password: '123456',
+        cpf: '1234567890',
+        address: 'foo',
+        address_number: '42',
+        zip_code: '123',
+        city: 'foo',
+        state: 'foo',
+        country: 'foo',
+        phone: '123456'
       )
     end
 

--- a/spec/requests/videos/show_spec.rb
+++ b/spec/requests/videos/show_spec.rb
@@ -38,8 +38,7 @@ RSpec.describe 'GET /videos/:id', type: :request do
         zip_code: '123',
         city: 'foo',
         state: 'foo',
-        country: 'foo',
-        phone: '123456'
+        country: 'foo'
       )
     end
 


### PR DESCRIPTION
I made this in the simplest way possible.
All the fields are in a single form.
Should we add some sort of basic validation to any of the fields, like CPF length? Now the only validation is not being empty.
* Update: Removed phone field, the client said it isn't necessary.
* The address isn't saved at Iugu yet (the API was not responding to make the tests)

![sign-up-form](https://user-images.githubusercontent.com/6249611/33147903-d89a954c-cfb0-11e7-9f4a-b8b9bca3b246.png)


