### PR TITLE
Prevents server error when series has no image and no video

### DIFF
--- a/app/models/series.rb
+++ b/app/models/series.rb
@@ -9,6 +9,13 @@ class Series < ApplicationRecord
   has_many :videos, dependent: :restrict_with_exception
 
   def image
-    @image ||= image_url ? image_url : videos.order(:sorting).first.image_url
+    @image ||= image_url ? image_url : first_video_image
+  end
+
+  private
+
+  def first_video_image
+    video = videos.order(:sorting).first
+    video.present? ? video.image_url : nil
   end
 end

--- a/spec/models/series_spec.rb
+++ b/spec/models/series_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe Series, type: :model do
       it { is_expected.to eq('http://foo') }
     end
 
-    context 'without series image_url set' do
+    context 'without series image_url set, with video' do
       let(:series) do
         Series.create!(
           name: 'foo bar',
@@ -72,6 +72,12 @@ RSpec.describe Series, type: :model do
       end
 
       it { is_expected.to eq(video.image_url) }
+    end
+
+    context 'without series image_url set, without video' do
+      let(:series) { Series.new }
+
+      it { is_expected.to eq(nil) }
     end
   end
 end


### PR DESCRIPTION
It's an edge case, but it happened today while they were uploading content manually.