### PR TITLE
Fixes input text on firefox and IE

### DIFF
--- a/app/assets/stylesheets/devise/_forms.sass
+++ b/app/assets/stylesheets/devise/_forms.sass
@@ -17,8 +17,7 @@
     .pink-input
       border: 5px solid $pink-color
       box-shadow: none
-      padding-top: 1.5rem
-      padding-bottom: 1.5rem
+      height: auto
     .field_with_errors
       .pink-input
         border: 5px solid $alert-color


### PR DESCRIPTION
I fixed this because it would be quick and have a high impact.

The client told me today there was a bug on inputs on Firefox and IE: the placeholder and value weren't appearing.
![screenshot from 2018-01-19 17-29-02](https://user-images.githubusercontent.com/6249611/35167914-45e639ac-fd3e-11e7-81b1-4046fe0695ec.png)

Now it's fixed:
![screenshot from 2018-01-19 17-30-22](https://user-images.githubusercontent.com/6249611/35167971-78a80334-fd3e-11e7-9b40-f07827c22b1a.png)
