### PR TITLE
Fixes cookie path

### DIFF
--- a/config/initializers/rack_affiliates.rb
+++ b/config/initializers/rack_affiliates.rb
@@ -1,3 +1,3 @@
 Rails.application.config.middleware.use(
-  Rack::Affiliates, param: 'aff', extra_params: [:campaign]
+  Rack::Affiliates, param: 'aff', path: '/', extra_params: [:campaign]
 )


### PR DESCRIPTION
Now cookies work from any URL.

I had to check out the last commit that was on Heroku and apply this one to it. I pushed this branch directly to Heroku/master, it's already live and working.

Should we move the whole `courses` part to a feature branch, while we're working on it? I think it makes sense since it can't be deployed, hence it shouldn't be on `master`.
