### PR TITLE
Allows to control course access through payment field

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -34,4 +34,9 @@ class User < ApplicationRecord
   def subscription
     subscriptions.order(:created_at).last
   end
+
+  def purchased?(course)
+    purchase = purchases.where(course: course).last
+    purchase&.paid
+  end
 end

--- a/app/policies/course_policy.rb
+++ b/app/policies/course_policy.rb
@@ -11,6 +11,6 @@ class CoursePolicy < ApplicationPolicy
 
   def watch?
     return unless user
-    user.courses.include? record
+    user.purchased? record
   end
 end

--- a/app/views/courses/_course_button.html.slim
+++ b/app/views/courses/_course_button.html.slim
@@ -1,4 +1,4 @@
-- if current_user && (current_user.courses.include? course)
+- if current_user && (current_user.purchased? course)
   = link_to 'Assistir',
     watch_course_path(course),
     class: 'button primary expanded'

--- a/spec/requests/courses/watch_spec.rb
+++ b/spec/requests/courses/watch_spec.rb
@@ -86,7 +86,8 @@ RSpec.describe 'GET /courses/:id/watch', type: :request do
     context 'who bought only other courses' do
       before do
         Purchase.create!(
-          user: user, course: course2, price: '100', installments: '1'
+          user: user, course: course2, price: '100',
+          installments: '1', paid: true
         )
         sign_in user
         get "/courses/#{course.id}/watch"
@@ -98,7 +99,8 @@ RSpec.describe 'GET /courses/:id/watch', type: :request do
     context 'who bought the course' do
       before do
         Purchase.create!(
-          user: user, course: course, price: '100', installments: '1'
+          user: user, course: course, price: '100',
+          installments: '1', paid: true
         )
         sign_in user
         get "/courses/#{course.id}/watch"
@@ -110,10 +112,42 @@ RSpec.describe 'GET /courses/:id/watch', type: :request do
     context 'who bought the course and others' do
       before do
         Purchase.create!(
-          user: user, course: course2, price: '100', installments: '1'
+          user: user, course: course2, price: '100',
+          installments: '1', paid: true
         )
         Purchase.create!(
-          user: user, course: course, price: '100', installments: '1'
+          user: user, course: course, price: '100',
+          installments: '1', paid: true
+        )
+        sign_in user
+        get "/courses/#{course.id}/watch"
+      end
+
+      it { is_expected.to have_http_status(:ok) }
+    end
+
+    context 'who bought the course and was expired' do
+      before do
+        Purchase.create!(
+          user: user, course: course, price: '100',
+          installments: '1', paid: false
+        )
+        sign_in user
+        get "/courses/#{course.id}/watch"
+      end
+
+      it { is_expected.to have_http_status(:found) }
+    end
+
+    context 'who bought the course again after expiration' do
+      before do
+        Purchase.create!(
+          user: user, course: course, price: '100',
+          installments: '1', paid: false
+        )
+        Purchase.create!(
+          user: user, course: course, price: '100',
+          installments: '1', paid: true
         )
         sign_in user
         get "/courses/#{course.id}/watch"


### PR DESCRIPTION
The client needed a way of removing course access manually after a given time. The only solution so far would be to delete the `purchase` record, but they would lose the information.

I updated the methods to check if the last purchase associated with that user/course is `paid`, so they can just use that flag to manually control the access.