### PR TITLE
Fixes devise error and contact email

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -44,7 +44,7 @@ class ApplicationController < ActionController::Base
 
   protected
 
-  def authenticate_user!
+  def authenticate_user!(options = {})
     if user_signed_in?
       super
     else

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -37,7 +37,7 @@
                 = l(@user.subscription.activated_at, format: :short)
         - else
           | Nenhuma assinatura encontrada.
-        = mail_to 'financeiro@pange.as',
+        = mail_to 'financeiro@pangeas.com.br',
           'Alterar Assinatura',
           subject: 'Alterar Assinatura',
           class: 'button success'
@@ -63,7 +63,7 @@
           ' contratado. Além disso, estamos sempre procurando melhorar... Então,
           ' por favor, antes nos informe o motivo da interrupção da busca por
           | Saúde e Liberdade.
-        = mail_to 'financeiro@pange.as',
+        = mail_to 'financeiro@pangeas.com.br',
           'Encerrar assinatura',
           subject: 'Encerrar Assinatura',
           class: 'button bg-dark-gray'


### PR DESCRIPTION
Clicking on "Alterar os dados" (`edit_user_registration_path`) was throwing a `wrong number of arguments` error at `authenticate_user!`, that was being called from inside Devise. I found this fix at Stack Overflow :grin: 

![screenshot from 2018-04-25 09-39-18](https://user-images.githubusercontent.com/6249611/39246322-951ae4ea-486c-11e8-8ff9-9cc6cbe24075.png)
